### PR TITLE
hackerne.ws link was missing.

### DIFF
--- a/js/inject/hackernews.js
+++ b/js/inject/hackernews.js
@@ -29,7 +29,7 @@ $(function() {
 
                 openPopup(a, title, url);
             });
-            
+
             // New link at the end
             var last = aList.last();
             last.after(a);

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "manifest_version": 2,
     "description": "Kippt.com's Chrome extension",
     "homepage_url": "https://kippt.com",
-    "icons": { 
+    "icons": {
         "16": "img/icon16.png",
         "48": "img/icon48.png",
         "128": "img/icon128.png"
@@ -14,7 +14,7 @@
       "contextMenus",
       "https://kippt.com/"
     ],
-    
+
     "web_accessible_resources": [
       "img/twitter-sprite.png",
       "img/icon16.png"
@@ -25,7 +25,7 @@
     "background": {
         "page" : "background.html"
     },
-    
+
     "browser_action": {
         "default_icon": "img/icon19.png",
         "default_title": "Kippt this page",
@@ -46,7 +46,9 @@
         "matches": [
             "*://news.ycombinator.com/",
             "*://news.ycombinator.net/",
-            "*://news.ycombinator.org/"
+            "*://news.ycombinator.org/",
+            "*://hackerne.ws/*"
+
         ]
     },
     {


### PR DESCRIPTION
I added `hackerne.ws` domain so `save to kippt` appear next to comments in main page as well as in comments page. 
