### PR TITLE
Fixed a problem in Google Reader injection

### DIFF
--- a/js/inject/googlereader.js
+++ b/js/inject/googlereader.js
@@ -12,9 +12,10 @@ $(function() {
         return $('.action-kippt', div).length > 0
     };
 
-    var getShareContent = function(el) {
-        var title = $('h2.entry-title', el).text();
-        var url = $('a.entry-original', el)[0].href;
+    var getShareContent = function (el) {
+        var link = $('a.entry-title-link', el);
+        var title = link.text();
+        var url = link.attr('href');
         return {title: title, url: url};
     };
 


### PR DESCRIPTION
The title of a selected feed item got fetched twice by the extension.
